### PR TITLE
Create smooth_sandstone_from_polished_sandstone.json

### DIFF
--- a/src/generated/resources/data/minecraft/recipes/smooth_sandstone_from_polished_sandstone.json
+++ b/src/generated/resources/data/minecraft/recipes/smooth_sandstone_from_polished_sandstone.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "embellishcraft:polished_sandstone"
+    }
+  ],
+  "result": {
+    "item": "minecraft:smooth_sandstone"
+  }
+}


### PR DESCRIPTION
Correcting a craft conflict with the vanilla smooth sandstone recipe due to misnamed file "smooth_sandstone.json" in the mod.